### PR TITLE
Add option to disable perk/spell/enemy progress in NT

### DIFF
--- a/noita_mod/core/init.lua
+++ b/noita_mod/core/init.lua
@@ -66,6 +66,21 @@ function is_valid_entity(entity_id)
     return entity_id ~= nil and entity_id ~= 0
 end
 
+--option to disable progress tracking, thanks dextercd for suggestion
+function SetProgressDisable(b)
+    if b then
+        GameAddFlagRun("NT_option_disable_progress")
+        GameAddFlagRun("no_progress_flags_perk")
+        GameAddFlagRun("no_progress_flags_animal")
+        GameAddFlagRun("no_progress_flags_action")
+    else
+        GameRemoveFlagRun("NT_option_disable_progress")
+        GameRemoveFlagRun("no_progress_flags_perk")
+        GameRemoveFlagRun("no_progress_flags_animal")
+        GameRemoveFlagRun("no_progress_flags_action")
+    end
+end
+
 function OnWorldPreUpdate()
     dofile("mods/noita-together/files/scripts/ui.lua")
 end
@@ -255,25 +270,9 @@ function OnWorldInitialized()
     dofile("mods/noita-together/files/ws/ws.lua")
 end
 
---option to disable progress tracking, thanks dextercd for suggestion
-function SetProgressDisable(b)
-    if b then
-        GameAddFlagRun("NT_option_disable_progress")
-        GameAddFlagRun("no_progress_flags_perk")
-        GameAddFlagRun("no_progress_flags_animal")
-        GameAddFlagRun("no_progress_flags_action")
-    else
-        GameRemoveFlagRun("NT_option_disable_progress")
-        GameRemoveFlagRun("no_progress_flags_perk")
-        GameRemoveFlagRun("no_progress_flags_animal")
-        GameRemoveFlagRun("no_progress_flags_action")
-    end
-end
-
 --used to detect settings changes
 --wiki: OnModSettingsChanged "Note: This callback doesn't appear to work. Modders have resorted to using OnPausedChanged instead to detect potential settings changes."
 function OnPausedChanged(is_paused, is_inventory_paused)
-    GamePrint("OnPausedChanged " .. (ModSettingGet("noita-together.NT_NO_STAT_PROGRESS") and "yes" or "no"))
     if not ModSettingGet("noita-together.NT_NO_STAT_PROGRESS") and GameHasFlagRun("NT_option_disable_progress") then
         --nt print_error("Removing no_progress flags, option disabled")
         SetProgressDisable(false)

--- a/noita_mod/core/init.lua
+++ b/noita_mod/core/init.lua
@@ -209,6 +209,13 @@ function OnPlayerSpawned(player_entity)
     if (ModSettingGet("noita-together.NT_HINTS")) then
         EntityLoad("mods/noita-together/files/entities/start_run_hint.xml", res_x - 45, res_y + 30)
     end
+
+    --option to disable progress tracking, thanks dextercd for suggestion
+    if (ModSettingGet("noita-together.NT_NO_STAT_PROGRESS")) then
+        GameAddFlagRun("no_progress_flags_perk")
+        GameAddFlagRun("no_progress_flags_animal")
+        GameAddFlagRun("no_progress_flags_action")
+    end
 end
 
 function OnPausePreUpdate()

--- a/noita_mod/core/init.lua
+++ b/noita_mod/core/init.lua
@@ -211,10 +211,9 @@ function OnPlayerSpawned(player_entity)
     end
 
     --option to disable progress tracking, thanks dextercd for suggestion
-    if (ModSettingGet("noita-together.NT_NO_STAT_PROGRESS")) then
-        GameAddFlagRun("no_progress_flags_perk")
-        GameAddFlagRun("no_progress_flags_animal")
-        GameAddFlagRun("no_progress_flags_action")
+    if (ModSettingGet("noita-together.NT_NO_STAT_PROGRESS") and not GameHasFlagRun("no_progress_flags_perk")) then
+        --nt print_error("Adding no_progress flags, option enabled and flags dont exist already")
+        SetProgressDisable(true)
     end
 end
 
@@ -254,4 +253,32 @@ end
 function OnWorldInitialized()
     --Moved this into OnWorldInitialized, it is inconsistent when included directly in init.lua 
     dofile("mods/noita-together/files/ws/ws.lua")
+end
+
+--option to disable progress tracking, thanks dextercd for suggestion
+function SetProgressDisable(b)
+    if b then
+        GameAddFlagRun("NT_option_disable_progress")
+        GameAddFlagRun("no_progress_flags_perk")
+        GameAddFlagRun("no_progress_flags_animal")
+        GameAddFlagRun("no_progress_flags_action")
+    else
+        GameRemoveFlagRun("NT_option_disable_progress")
+        GameRemoveFlagRun("no_progress_flags_perk")
+        GameRemoveFlagRun("no_progress_flags_animal")
+        GameRemoveFlagRun("no_progress_flags_action")
+    end
+end
+
+--used to detect settings changes
+--wiki: OnModSettingsChanged "Note: This callback doesn't appear to work. Modders have resorted to using OnPausedChanged instead to detect potential settings changes."
+function OnPausedChanged(is_paused, is_inventory_paused)
+    GamePrint("OnPausedChanged " .. (ModSettingGet("noita-together.NT_NO_STAT_PROGRESS") and "yes" or "no"))
+    if not ModSettingGet("noita-together.NT_NO_STAT_PROGRESS") and GameHasFlagRun("NT_option_disable_progress") then
+        --nt print_error("Removing no_progress flags, option disabled")
+        SetProgressDisable(false)
+    elseif ModSettingGet("noita-together.NT_NO_STAT_PROGRESS") and not GameHasFlagRun("NT_option_disable_progress") then
+        --nt print_error("Addding no_progress flags, option enabled")
+        SetProgressDisable(true)
+    end
 end

--- a/noita_mod/core/settings.lua
+++ b/noita_mod/core/settings.lua
@@ -11,6 +11,13 @@ mod_settings =
         scope=MOD_SETTING_SCOPE_RUNTIME
 	},
 	{
+		id = "NT_NO_STAT_PROGRESS",
+		ui_name = "Disable progress",
+		ui_description = "Disable progress tracking of perks, spells and enemies",
+		value_default = false,
+        scope=MOD_SETTING_SCOPE_RUNTIME
+	},
+	{
 		id = "NT_GHOST_OPACITY",
 		ui_name = "Player ghost opacity",
 		value_default = 1.0,


### PR DESCRIPTION
Implements #80 

The option defaults to OFF (progress will still be enabled by default) - Should gather some community feedback as to if we want to default this to ON?