### PR TITLE
Extra max HP fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Show proper sampo name when picked up by other players
 - Update protobuf files :)
 - Alternate message when other player picks up sampo when we already have ours
+- Update extra max HP and better max HP pickups to no longer cause infinite health on client sync issues (does not fix the bug, but logs when it breaks, and gives the user the min HP from the heart)
 
 # Noita Together Nemesis
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Alternate message when other player picks up sampo when we already have ours
 - Update extra max HP and better max HP pickups to no longer cause infinite health on client sync issues (does not fix the bug, but logs when it breaks, and gives the user the min HP from the heart)
 - Better extra max HP gives more health at its minimum point
+- Extra max HP minimum health given now scales with stronger hearts
 
 # Noita Together Nemesis
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Update protobuf files :)
 - Alternate message when other player picks up sampo when we already have ours
 - Update extra max HP and better max HP pickups to no longer cause infinite health on client sync issues (does not fix the bug, but logs when it breaks, and gives the user the min HP from the heart)
+- Better extra max HP gives more health at its minimum point
 
 # Noita Together Nemesis
 

--- a/noita_mod/core/files/append/heart_append.lua
+++ b/noita_mod/core/files/append/heart_append.lua
@@ -17,7 +17,11 @@ function shared_heart(entity_item, entity_who_picked, name)
             max_hp = tonumber(ComponentGetValue(damagemodel, "max_hp"))
             max_hp_old = max_hp
             if (GameHasFlagRun("NT_sync_hearts")) then
-                max_hp = max_hp + math.max(0.16 ,(1 / (playercount)) * multiplier)
+                local expected_max_hp = 0.16
+                if(playercount > 0) then
+                    expected_max_hp = (1 / (playercount)) * multiplier
+                end
+                max_hp = max_hp + math.max(0.16 , expected_max_hp)
             else
                 max_hp = max_hp + 1 * multiplier
             end
@@ -39,6 +43,11 @@ function shared_heart(entity_item, entity_who_picked, name)
     end
 
     GamePrintImportant("$log_heart", description)
+    if playercount == 0 or true == true then
+        description = GameTextGet("$noitatogether_heart_blocked_playercount")
+        print_error(description)
+        GamePrint(description)
+    end
     GameTriggerMusicCue("item")
     EntityKill(entity_item)
 end

--- a/noita_mod/core/files/append/heart_append.lua
+++ b/noita_mod/core/files/append/heart_append.lua
@@ -43,7 +43,7 @@ function shared_heart(entity_item, entity_who_picked, name)
     end
 
     GamePrintImportant("$log_heart", description)
-    if playercount == 0 or true == true then
+    if playercount == 0 then
         description = GameTextGet("$noitatogether_heart_blocked_playercount")
         print_error(description)
         GamePrint(description)

--- a/noita_mod/core/files/append/heart_append.lua
+++ b/noita_mod/core/files/append/heart_append.lua
@@ -9,6 +9,7 @@ function shared_heart(entity_item, entity_who_picked, name)
     local max_hp_old = 0
     local max_hp = 0
     local multiplier = tonumber( GlobalsGetValue( "HEARTS_MORE_EXTRA_HP_MULTIPLIER", "1" ) )
+    local min_hp_to_add = 0.16 * multiplier
 
     local x, y = EntityGetTransform(entity_item)
     local playercount = NT.player_count
@@ -17,11 +18,11 @@ function shared_heart(entity_item, entity_who_picked, name)
             max_hp = tonumber(ComponentGetValue(damagemodel, "max_hp"))
             max_hp_old = max_hp
             if (GameHasFlagRun("NT_sync_hearts")) then
-                local expected_max_hp = 0.16
+                local expected_max_hp = min_hp_to_add
                 if(playercount > 0) then
                     expected_max_hp = (1 / (playercount)) * multiplier
                 end
-                max_hp = max_hp + math.max(0.16 , expected_max_hp)
+                max_hp = max_hp + math.max(min_hp_to_add , expected_max_hp)
             else
                 max_hp = max_hp + 1 * multiplier
             end

--- a/noita_mod/core/files/append/heart_better_append.lua
+++ b/noita_mod/core/files/append/heart_better_append.lua
@@ -9,6 +9,7 @@ function shared_heart(entity_item, entity_who_picked, name)
     local max_hp_old = 0
     local max_hp = 0
     local multiplier = tonumber( GlobalsGetValue( "HEARTS_MORE_EXTRA_HP_MULTIPLIER", "1" ) )
+    local min_hp_to_add = 0.32 * multiplier
 
     local x, y = EntityGetTransform(entity_item)
     local playercount = NT.player_count
@@ -17,11 +18,11 @@ function shared_heart(entity_item, entity_who_picked, name)
             max_hp = tonumber(ComponentGetValue(damagemodel, "max_hp"))
             max_hp_old = max_hp
             if (GameHasFlagRun("NT_sync_hearts")) then
-                local expected_max_hp = 0.32
+                local expected_max_hp = min_hp_to_add
                 if(playercount > 0) then
                     expected_max_hp = (2 / (playercount)) * multiplier
                 end
-                max_hp = max_hp + math.max(0.32 , expected_max_hp)
+                max_hp = max_hp + math.max(min_hp_to_add , expected_max_hp)
             else
                 max_hp = max_hp + 2 * multiplier
             end

--- a/noita_mod/core/files/append/heart_better_append.lua
+++ b/noita_mod/core/files/append/heart_better_append.lua
@@ -43,7 +43,7 @@ function shared_heart(entity_item, entity_who_picked, name)
     end
 
     GamePrintImportant("$log_heart_better", description)
-    if playercount == 0 or true == true then
+    if playercount == 0 then
         description = GameTextGet("$noitatogether_heart_blocked_playercount")
         print_error(description)
         GamePrint(description)

--- a/noita_mod/core/files/append/heart_better_append.lua
+++ b/noita_mod/core/files/append/heart_better_append.lua
@@ -17,7 +17,11 @@ function shared_heart(entity_item, entity_who_picked, name)
             max_hp = tonumber(ComponentGetValue(damagemodel, "max_hp"))
             max_hp_old = max_hp
             if (GameHasFlagRun("NT_sync_hearts")) then
-                max_hp = max_hp + math.max(0.16 ,(2 / (playercount)) * multiplier)
+                local expected_max_hp = 0.32
+                if(playercount > 0) then
+                    expected_max_hp = (2 / (playercount)) * multiplier
+                end
+                max_hp = max_hp + math.max(0.32 , expected_max_hp)
             else
                 max_hp = max_hp + 2 * multiplier
             end
@@ -39,6 +43,11 @@ function shared_heart(entity_item, entity_who_picked, name)
     end
 
     GamePrintImportant("$log_heart_better", description)
+    if playercount == 0 or true == true then
+        description = GameTextGet("$noitatogether_heart_blocked_playercount")
+        print_error(description)
+        GamePrint(description)
+    end
     GameTriggerMusicCue("item")
     EntityKill(entity_item)
 end

--- a/noita_mod/core/files/scripts/utils.lua
+++ b/noita_mod/core/files/scripts/utils.lua
@@ -161,6 +161,7 @@ function PlayerHeartPickup(perk, userId)
     local variablestorages = EntityGetComponent(entity_who_picked, "VariableStorageComponent")
     local playercount = NT.player_count or 1
     local multiplier = tonumber( GlobalsGetValue( "HEARTS_MORE_EXTRA_HP_MULTIPLIER", "1" ) )
+    local min_hp_to_add = 0.16 * multiplier
 
     if (damagemodels ~= nil) then
         for i, damagemodel in ipairs(damagemodels) do
@@ -168,7 +169,11 @@ function PlayerHeartPickup(perk, userId)
             local max_hp = ComponentGetValue2(damagemodel, "max_hp")
             local added = 1 * multiplier
             if (GameHasFlagRun("NT_sync_hearts")) then
-                added = math.max(0.16 ,(1 / (playercount)) * multiplier)
+                local expected_max_hp = min_hp_to_add
+                if(playercount > 0) then
+                    expected_max_hp = (1 / (playercount)) * multiplier
+                end
+                added = max_hp + math.max(min_hp_to_add , expected_max_hp)
             end
             max_hp = max_hp + added
 
@@ -183,6 +188,11 @@ function PlayerHeartPickup(perk, userId)
     end
     GameTriggerMusicCue("item")
     GamePrint(GameTextGet("$noitatogether_player_got_heart", player_name))
+    if playercount == 0 then
+        description = GameTextGet("$noitatogether_heart_blocked_playercount")
+        print_error(description)
+        GamePrint(description)
+    end
 end
 
 function PlayerOrbPickup(id, userId)

--- a/noita_mod/core/files/translations/translations.csv
+++ b/noita_mod/core/files/translations/translations.csv
@@ -48,6 +48,7 @@ noitatogether_angered_gods_subtitle,Good luck,,,,,,,,,,,,subtitle of message whe
 noitatogether_player_got_heart,$0 picked up a heart,,,,,,,,,,,,message when player picks up a heart,
 noitatogether_player_got_orb_had,$0 found an orb of knowledge you had already found,,,,,,,,,,,,message when player picks up an orb you already found,
 noitatogether_player_got_orb,$0 found an orb of knowledge,,,,,,,,,,,,message when player picks up an orb,
+noitatogether_heart_blocked_playercount,Unable to calculate proper health increase. Gave the min hp increase (bug),,,,,,,,,,,,message when player can't benefit from hearts,
 noitatogether_player_died,$0 died,,,,,,,,,,,,message when player died generically,
 noitatogether_run_end_lowhp_title,Not enough life force,,,,,,,,,,,,title of message when run ends due to respawn penalty dropping hp too low,
 noitatogether_run_end_lowhp_subtitle,Your teammate stays dead and the run ends,,,,,,,,,,,,subtitle of message when run ends due to respawn penalty dropping hp too low,

--- a/noita_mod/core/init.lua
+++ b/noita_mod/core/init.lua
@@ -143,6 +143,7 @@ function OnWorldPostUpdate()
                 local sampo_check = CheckSampoStatus()
                 if (sampo_check) then SpawnSampo() end
             end
+--             TODO how do we handle player count potentially being out of sync here? How does this happen?
             if (NT.sampo_pickup and NT.player_count == NT.players_sampo and NT.boss_fight == false) then
                 StartBossFight()
             end


### PR DESCRIPTION
Update extra max HP and better max HP pickups to no longer cause infinite health on client sync issues (does not fix the bug, but logs when it breaks, and gives the user the min HP from the heart)