### PR TITLE
Player ghost cosmetics fixes, refactoring

### DIFF
--- a/noita_mod/core/files/scripts/util/player_ghosts.lua
+++ b/noita_mod/core/files/scripts/util/player_ghosts.lua
@@ -1,0 +1,231 @@
+--move player ghost utility code into this file!
+function SpawnPlayerGhosts(player_list)
+    for userId, player in pairs(player_list) do
+        local ghost = SpawnPlayerGhost(player, userId)
+        
+        --this only happens if SpawnPlayerGhost for some reason returns nil
+        --most likely reason for this is because noita emotes overwrote the function
+        --see the interoperability notice on SpawnPlayerGhost
+        if ghost == nil then
+            --this is in a weird spot on purpose, see interop notice on SpawnPlayerGhost
+            --invalidate stored ghost entity (it will be recached)
+            player.ghostEntityId = nil 
+            --apply cosmetics, finding ghost in process
+            SetPlayerGhostCosmetics(userId, nil)
+        end
+    end
+end
+
+--interoperability notice: noita emotes overwrites this function, so let infinitesunrise know if we change it
+--might(?) still work when moved into this file and dofile() included from original utils.lua???
+function SpawnPlayerGhost(player, userId)
+    local ghost = EntityLoad("mods/noita-together/files/entities/ntplayer.xml", 0, 0)
+    AppendName(ghost, player.name)
+    local vars = EntityGetComponent(ghost, "VariableStorageComponent")
+    for _, var in pairs(vars) do
+        local name = ComponentGetValue2(var, "name")
+        if (name == "userId") then
+            ComponentSetValue2(var, "value_string", userId)
+        end
+        if (name == "inven") then
+            ComponentSetValue2(var, "value_string", json.encode(PlayerList[userId].inven))
+        end
+    end
+    if (player.x ~= nil and player.y ~= nil) then
+        EntitySetTransform(ghost, player.x, player.y)
+    end
+
+    --cache the ghost's entity id for this player
+    player.ghostEntityId = ghost
+    --apply cosmetics (if known)
+    SetPlayerGhostCosmetics(userId, ghost)
+    --return reference to created ghost
+    return ghost
+end
+
+function DespawnPlayerGhosts()
+    local ghosts = EntityGetWithTag("nt_ghost")
+    for _, eid in pairs(ghosts) do
+        EntityKill(eid)
+    end
+
+    --clear cached ghosts from all players
+    for userId, entry in pairs(PlayerList) do
+        --nt print_error("DespawnPlayerGhosts: invalidating cached ghost for userId " .. userId)
+        entry.ghostEntityId = nil
+    end
+end
+
+function DespawnPlayerGhost(userId)
+    local ghosts = EntityGetWithTag("nt_ghost")
+    for _, ghost in pairs(ghosts) do
+        local vars = EntityGetComponent(ghost, "VariableStorageComponent")
+        for _, var in pairs(vars) do
+            local name = ComponentGetValue2(var, "name")
+            if (name == "userId") then
+                local id = ComponentGetValue2(var, "value_string")
+                if (id == userId) then EntityKill(ghost) end
+            end
+        end
+    end
+end
+
+function TeleportPlayerGhost(data)
+    local ghosts = EntityGetWithTag("nt_ghost")
+
+    for _, ghost in pairs(ghosts) do
+        local id_comp = get_variable_storage_component(ghost, "userId")
+        local userId = ComponentGetValue2(id_comp, "value_string")
+        if (userId == data.userId) then
+            EntitySetTransform(ghost, data.x, data.y)
+            break
+        end
+    end
+end
+
+function MovePlayerGhost(data)
+    local ghosts = EntityGetWithTag("nt_ghost")
+
+    for _, ghost in pairs(ghosts) do
+        local id_comp = get_variable_storage_component(ghost, "userId")
+        local userId = ComponentGetValue2(id_comp, "value_string")
+        if (userId == data.userId) then
+            local dest = get_variable_storage_component(ghost, "dest")
+            
+            ComponentSetValue2(dest, "value_string", data.jank)
+            break
+        end
+    end
+end
+
+function UpdatePlayerGhost(data)
+    local ghosts = EntityGetWithTag("nt_ghost")
+    local stuff = {}
+    local inven = ","
+    for i, wand in ipairs(data.inven) do
+        inven = inven .. "," .. tostring(wand.stats.inven_slot) .. "," .. wand.stats.sprite .. ","
+    end
+    for _, ghost in pairs(ghosts) do
+        local id_comp = get_variable_storage_component(ghost, "userId")
+        local userId = ComponentGetValue2(id_comp, "value_string")
+        if (userId == data.userId) then
+            local dest = get_variable_storage_component(ghost, "inven")
+            ComponentSetValue2(dest, "value_string", inven)
+            break
+        end
+    end
+end
+
+--PLAYER GHOST COSMETICS
+function GetPlayerCosmeticFlags()
+    local data = {}
+    if HasFlagPersistent( "secret_amulet" ) then
+        table.insert(data, "player_amulet")
+    end
+    if HasFlagPersistent( "secret_amulet_gem" ) then
+        table.insert(data, "player_amulet_gem")
+    end
+    if HasFlagPersistent( "secret_hat" ) then
+        table.insert(data, "player_hat2")
+    end
+    return data
+end
+
+function StorePlayerGhostCosmetic(data, refresh)
+    if PlayerList[data.userId] ~= nil then
+        local cosmeticFlags = {}
+
+        --nt print_error("StorePlayerGhostCosmetic: store " .. ((data and #(data.flags)) or "(nil?)") .. " cosmetic flags for userId " .. data.userId)
+        if data.flags and #(data.flags) > 0 then
+            for _, flag in pairs(data.flags) do
+                cosmeticFlags[#cosmeticFlags+1] = flag
+                --nt print_error(" + " .. flag)
+            end
+        end
+
+        PlayerList[data.userId].cosmeticFlags = cosmeticFlags
+
+        if refresh then
+            SetPlayerGhostCosmetics(data.userId)
+        end
+    else
+        --nt print_error("StorePlayerGhostCosmetic: invalid userId " .. data.userId)
+    end
+end
+
+--utility function to get the ghost entity for a particular player, tries cached value then checks all ghosts
+function GetPlayerGhost(userId)
+    --store/fetch player ghost's entity from its PlayerList object
+    local eid = PlayerList[userId].ghostEntityId
+    if eid ~= 0 and EntityHasTag(eid, "nt_ghost") then
+        local id_comp = get_variable_storage_component(ghost, "userId")
+        local entityUserId = ComponentGetValue2(id_comp, "value_string")
+
+        if entityUserId == userId then
+            --nt print_error("GetPlayerGhost: use cached ghost " .. eid .. " for userId " .. userId)
+            return eid
+        end
+    end
+
+    --ghostEntityId was not the ghost, need to check all ghosts
+    local ghosts = EntityGetWithTag("nt_ghost")
+
+    for _, ghost in pairs(ghosts) do
+        local id_comp = get_variable_storage_component(ghost, "userId")
+        local entityUserId = ComponentGetValue2(id_comp, "value_string")
+
+        if entityUserId == userId then
+            --cache this value for later calls
+            PlayerList[userId].ghostEntityId = ghost
+            --nt print_error("GetPlayerGhost: caching ghost " .. ghost .. " for userId " .. userId)
+            return ghost
+        end
+    end
+
+    --failed to find
+    --nt print_error("GetPlayerGhost failed to find for userId " .. userId)
+    return nil
+end
+
+--set cosmetics on a player's ghost
+--userId is the player userid, non-nil
+--ghost is the ghost entity, if nil try to find it
+function SetPlayerGhostCosmetics(userId, ghost)
+    --nt print_error("SetPlayerGhostCosmetics: ghost " .. (ghost or "(nil)") .. ", userId " .. userId)
+
+    --get player ghost entity
+    if not ghost then
+        ghost = GetPlayerGhost(userId)
+
+        if not ghost then
+            --nt print_error("SetPlayerGhostCosmetics: failed to find player's ghost???")
+            --should we print a real error?
+            return
+        end
+    end
+
+    --TODO do we need to be able to CLEAR these flags ever?
+    for _, flag in pairs(PlayerList[userId].cosmeticFlags) do
+        EntitySetComponentsWithTagEnabled(ghost, flag, true)
+    end
+end
+
+--not used?
+function SetAllPlayerGhostCosmetics()
+    --nt print_error("SetAllPlayerGhostCosmetics")
+    local ghosts = EntityGetWithTag("nt_ghost")
+
+    for _, ghost in pairs(ghosts) do
+        local id_comp = get_variable_storage_component(ghost, "userId")
+        local userId = ComponentGetValue2(id_comp, "value_string")
+        local playerEntry = PlayerList[userId]
+        if playerEntry then
+            for __, flag in pairs(playerEntry.cosmeticFlags or {}) do
+                EntitySetComponentsWithTagEnabled( ghost, flag, true )
+            end
+            --cache the ghost id for this player for later use
+            playerEntry.ghostEntityId = ghost
+            break
+        end
+    end
+end

--- a/noita_mod/core/files/scripts/util/player_ghosts.lua
+++ b/noita_mod/core/files/scripts/util/player_ghosts.lua
@@ -221,23 +221,3 @@ function SetPlayerGhostCosmetics(userId, ghost)
         EntitySetComponentsWithTagEnabled(ghost, flag, true)
     end
 end
-
---not used?
-function SetAllPlayerGhostCosmetics()
-    --nt print_error("SetAllPlayerGhostCosmetics")
-    local ghosts = EntityGetWithTag("nt_ghost")
-
-    for _, ghost in pairs(ghosts) do
-        local id_comp = get_variable_storage_component(ghost, "userId")
-        local userId = ComponentGetValue2(id_comp, "value_string")
-        local playerEntry = PlayerList[userId]
-        if playerEntry then
-            for __, flag in pairs(playerEntry.cosmeticFlags or {}) do
-                EntitySetComponentsWithTagEnabled( ghost, flag, true )
-            end
-            --cache the ghost id for this player for later use
-            playerEntry.ghostEntityId = ghost
-            break
-        end
-    end
-end

--- a/noita_mod/core/files/scripts/util/player_ghosts.lua
+++ b/noita_mod/core/files/scripts/util/player_ghosts.lua
@@ -42,7 +42,7 @@ function SpawnPlayerGhost(player, userId)
     --apply cosmetics (if known)
     SetPlayerGhostCosmetics(userId, ghost)
     --refresh inventory
-    SetPlayerGhostInventory(userId, nil)
+    SetPlayerGhostInventory(userId, ghost)
     --return reference to created ghost
     return ghost
 end
@@ -105,9 +105,9 @@ end
 --utility function to get the ghost entity for a particular player, tries cached value then checks all ghosts
 function GetPlayerGhost(userId)
     --store/fetch player ghost's entity from its PlayerList object
-    local eid = PlayerList[userId].ghostEntityId
+    local eid = PlayerList[userId].ghostEntityId or 0
     if eid ~= 0 and EntityHasTag(eid, "nt_ghost") then
-        local id_comp = get_variable_storage_component(ghost, "userId")
+        local id_comp = get_variable_storage_component(eid, "userId")
         local entityUserId = ComponentGetValue2(id_comp, "value_string")
 
         if entityUserId == userId then

--- a/noita_mod/core/files/scripts/utils.lua
+++ b/noita_mod/core/files/scripts/utils.lua
@@ -5,6 +5,9 @@ if not async then
     dofile("mods/noita-together/files/scripts/coroutines.lua")
 end
 
+--util includes
+dofile("mods/noita-together/files/scripts/util/player_ghosts.lua")
+
 function GetPlayer()
     local player = EntityGetWithTag("player_unit") or nil
     if player ~= nil then
@@ -215,112 +218,6 @@ function PlayerOrbPickup(id, userId)
             EntitySetTransform(orb, x, y)
         end
     )
-end
-
-function SpawnPlayerGhosts(player_list)
-    for userId, player in pairs(player_list) do
-        SpawnPlayerGhost(player, userId)
-    end
-end
-
-function SpawnPlayerGhost(player, userId)
-    local ghost = EntityLoad("mods/noita-together/files/entities/ntplayer.xml", 0, 0)
-    AppendName(ghost, player.name)
-    local vars = EntityGetComponent(ghost, "VariableStorageComponent")
-    for _, var in pairs(vars) do
-        local name = ComponentGetValue2(var, "name")
-        if (name == "userId") then
-            ComponentSetValue2(var, "value_string", userId)
-        end
-        if (name == "inven") then
-            ComponentSetValue2(var, "value_string", json.encode(PlayerList[userId].inven))
-        end
-    end
-    if (player.x ~= nil and player.y ~= nil) then
-        EntitySetTransform(ghost, player.x, player.y)
-    end
-end
-
-function DespawnPlayerGhosts()
-    local ghosts = EntityGetWithTag("nt_ghost")
-    for _, eid in pairs(ghosts) do
-        EntityKill(eid)
-    end
-end
-
-function DespawnPlayerGhost(userId)
-    local ghosts = EntityGetWithTag("nt_ghost")
-    for _, ghost in pairs(ghosts) do
-        local vars = EntityGetComponent(ghost, "VariableStorageComponent")
-        for _, var in pairs(vars) do
-            local name = ComponentGetValue2(var, "name")
-            if (name == "userId") then
-                local id = ComponentGetValue2(var, "value_string")
-                if (id == userId) then EntityKill(ghost) end
-            end
-        end
-    end
-end
-
-function TeleportPlayerGhost(data)
-    local ghosts = EntityGetWithTag("nt_ghost")
-
-    for _, ghost in pairs(ghosts) do
-        local id_comp = get_variable_storage_component(ghost, "userId")
-        local userId = ComponentGetValue2(id_comp, "value_string")
-        if (userId == data.userId) then
-            EntitySetTransform(ghost, data.x, data.y)
-            break
-        end
-    end
-end
-
-function MovePlayerGhost(data)
-    local ghosts = EntityGetWithTag("nt_ghost")
-
-    for _, ghost in pairs(ghosts) do
-        local id_comp = get_variable_storage_component(ghost, "userId")
-        local userId = ComponentGetValue2(id_comp, "value_string")
-        if (userId == data.userId) then
-            local dest = get_variable_storage_component(ghost, "dest")
-            
-            ComponentSetValue2(dest, "value_string", data.jank)
-            break
-        end
-    end
-end
-
-function UpdatePlayerGhost(data)
-    local ghosts = EntityGetWithTag("nt_ghost")
-    local stuff = {}
-    local inven = ","
-    for i, wand in ipairs(data.inven) do
-        inven = inven .. "," .. tostring(wand.stats.inven_slot) .. "," .. wand.stats.sprite .. ","
-    end
-    for _, ghost in pairs(ghosts) do
-        local id_comp = get_variable_storage_component(ghost, "userId")
-        local userId = ComponentGetValue2(id_comp, "value_string")
-        if (userId == data.userId) then
-            local dest = get_variable_storage_component(ghost, "inven")
-            ComponentSetValue2(dest, "value_string", inven)
-            break
-        end
-    end
-end
-
-function UpdatePlayerGhostCosmetic(data)
-    local ghosts = EntityGetWithTag("nt_ghost")
-
-    for _, ghost in pairs(ghosts) do
-        local id_comp = get_variable_storage_component(ghost, "userId")
-        local userId = ComponentGetValue2(id_comp, "value_string")
-        if (userId == data.userId) then
-            for __, flag in pairs(data.flags) do
-                EntitySetComponentsWithTagEnabled( ghost, flag, true )
-            end
-            break
-        end
-    end
 end
 
 function AppendName(entity, name)

--- a/noita_mod/core/files/ws/events.lua
+++ b/noita_mod/core/files/ws/events.lua
@@ -1,5 +1,6 @@
 dofile( "data/scripts/perks/perk.lua" )
 dofile( "mods/noita-together/files/scripts/hourglass_events.lua")
+dofile( "mods/noita-together/files/scripts/util/player_ghost_cosmetics.lua")
 
 customEvents = {
     PlayerPOI = function(data)
@@ -82,7 +83,7 @@ customEvents = {
         UpdatePlayerGhost(data)
     end,
     PlayerCosmeticFlags = function(data)
-        UpdatePlayerGhostCosmetic(data)
+        StorePlayerGhostCosmetic(data, true)
     end,
     SecretHourglass = HandleHourglassEvent
 }
@@ -192,6 +193,10 @@ wsEvents = {
             location = "Mountain",
             sampo = false,
             inven = {},
+            --cached entity ID for player ghost - check before any use!
+            ghostEntityId = 0,
+            --player cosmetic (crown,amulet,?) tracking
+            cosmeticFlags = {},
             --reasonable start for health check values
             HealthCheck = { lastPosUpdate = GameGetFrameNum() }
         }

--- a/noita_mod/core/files/ws/events.lua
+++ b/noita_mod/core/files/ws/events.lua
@@ -1,6 +1,6 @@
 dofile( "data/scripts/perks/perk.lua" )
 dofile( "mods/noita-together/files/scripts/hourglass_events.lua")
-dofile( "mods/noita-together/files/scripts/util/player_ghost_cosmetics.lua")
+dofile( "mods/noita-together/files/scripts/util/player_ghosts.lua")
 
 customEvents = {
     PlayerPOI = function(data)
@@ -80,7 +80,8 @@ customEvents = {
         local inven = jankson.decode(data.inven)
         PlayerList[data.userId].inven = inven
         data.inven = inven
-        UpdatePlayerGhost(data)
+        SetPlayerGhostInventory(data.userId)
+        --StorePlayerGhostInventory(data)
     end,
     PlayerCosmeticFlags = function(data)
         StorePlayerGhostCosmetic(data, true)


### PR DESCRIPTION
Some (WIP) improvements to player ghost cosmetics (crown, amulet, more to come?) and other player ghost tracking

- Moving player ghost related code from utils.lua to a separate utils/player_ghosts.lua. This gets included by utils.lua, so shouldn't change much in itself.
- Caching player's player-ghost entity id in the player's entry in the PlayerList table. This allows quick access to the ghost entity without having to iterate over all (up to 90!) ghost entities every time we do something
- Storing the player-ghost cosmetic flags in the same PlayerList table entry. This allows player-ghosts to get their crowns and amulets back when you hide and re-show ghosts. Fixes #82
- Wands no longer disappear when hiding and re-showing ghosts either

~~Need to periodically (and/or on change/request) re-send cosmetic information; ghost cosmetics and held wand also disappear when mod restarting (and we lose track of them in the PlayerList)~~ Let's leave resyncing PlayerList state after a mod restart to another PR for now?