### PR TITLE
Fix noita emotes broken by extra / out of place dofile

### DIFF
--- a/noita_mod/core/files/ws/events.lua
+++ b/noita_mod/core/files/ws/events.lua
@@ -1,6 +1,5 @@
 dofile( "data/scripts/perks/perk.lua" )
 dofile( "mods/noita-together/files/scripts/hourglass_events.lua")
-dofile( "mods/noita-together/files/scripts/util/player_ghosts.lua")
 
 customEvents = {
     PlayerPOI = function(data)


### PR DESCRIPTION
player_ghosts.lua was being dofile-included more than once (in utils.lua and events.lua) - this happened to clobber appended replacements by noita emotes. While the emotes mod shouldn't outright replace our functions if possible, the workaround wasn't working anymore either.

Long story short, removing this dofile makes noita emotes work again with the recent player ghost fixes in #86 . oops.