### PR TITLE
Fix NT.HealthCheck table access in sometimes illegal way

### DIFF
--- a/noita_mod/core/files/store.lua
+++ b/noita_mod/core/files/store.lua
@@ -28,6 +28,6 @@ if (NT.initialized ~= true) then
     NT.gold_queue = 0
 
     --"Health Check" values for making sure we're running OK
-    NT.HealthCheck = {}
-    NT.HealthCheck.AsyncLoopLastFrame = -1
+    NT.HealthCheck = {AsyncLoopLastFrame=-1} --accessing table members when global store is not ready breaks random scripts...
+    --NT.HealthCheck.AsyncLoopLastFrame = -1 --aka dont do this, do the above
 end


### PR DESCRIPTION
This was causing (among other things perhaps?) the hourglass trigger appends to not work after a mod restart, because NT.HealthCheck could not be set to an empty table at init (global store not yet ready?), which the next line then attempts to access and fails, throwing a lua error.