### PR TITLE
[WIP - do not merge] Changes for new NT lobby server

### DIFF
--- a/nt-app/src/store/index.js
+++ b/nt-app/src/store/index.js
@@ -313,7 +313,7 @@ export default new Vuex.Store({
             state.lobbies = payload
         },
         setRoom: (state, payload) => {
-            state.room = payload
+            state.room = Object.assign(state.room, payload);
             for (const user of state.room.users) {
                 user.color = randomColor()
             }
@@ -323,7 +323,7 @@ export default new Vuex.Store({
             state.room = Object.assign(room, payload)
         },
         roomFlagsUpdated: (state, payload) => {
-            const mode = state.room.gamemode
+            const mode = state.room.gamemode || 0
             const fDefaults = state.defaultFlags[mode]
             if (!fDefaults) { return }
             state.roomFlags = payload.flags.map(val => {
@@ -448,7 +448,7 @@ export default new Vuex.Store({
             commit("setLoading", true)
             ipcRenderer.send("CLIENT_MESSAGE", { key: "cRoomCreate", payload })
             ipcRenderer.once("sRoomCreated", (event, data) => {
-                commit("setDefaultFlags", data.gamemode)
+                commit("setDefaultFlags", data.gamemode || 0)
                 commit("setRoom", data)
                 commit("setLoading", false)
                 dispatch("sendFlags")


### PR DESCRIPTION
Some small changes to the electron app were required for compatibility with the leaner proto messages sent by protobuf-es (specifically, protobuf-es generates compliant protobufs that elide the zero value, but protobufjs decodes these as undefined instead of the zero value).

Additionally, some code was added to send only the most recent frame across the internet, and to round the values to be less granular + only send updates when these rounded values have changed.