### PR TITLE
fix settings typo confusing mouse codes for joystick codes

### DIFF
--- a/noita_mod/core/settings.lua
+++ b/noita_mod/core/settings.lua
@@ -164,7 +164,7 @@ function input_listen()
             end
         end
     end
-    for _, code in pairs(mouse_codes) do
+    for _, code in pairs(joystick_codes) do
         if InputIsJoystickButtonDown(0, code) then
             there_is_input = true
             there_has_been_input = true


### PR DESCRIPTION
Conga noticed a discrepancy in my emote keybind settings, I mistakenly refer to mouse_codes for evaluating both mouse and joystick inputs. Should be joystick_codes for joystick inputs!