### PR TITLE
Bump nt-message for https://github.com/Noita-Together/nt-message/pull/1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "buildClient": "yarn workspace nt-app electron:build"
   },
   "dependencies": {
-    "@noita-together/nt-message": "^0.0.1",
+    "@noita-together/nt-message": "1.0.1",
     "axios": "^1.4.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1114,13 +1114,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noita-together/nt-message@npm:^0.0.1":
-  version: 0.0.1
-  resolution: "@noita-together/nt-message@npm:0.0.1"
+"@noita-together/nt-message@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@noita-together/nt-message@npm:1.0.1"
   dependencies:
     long: ^5.2.3
     protobufjs: ^7.2.5
-  checksum: 2438d2ceb10d8ab9a19d73183edc57b87692eb913acaed299a2c5a74b46d494292f52ae8eedba0a64402468bbc3016e4d42f16b40f7ed79079e26d862a645e1f
+  checksum: 13cb42bf60c4048d33cd0f599e67f35946f757b34f64ba3b5b8bc4e50ad98d821d0288f0705790ff6863d45b823832247f82884ad7978b3a93b1b0338d09a593
   languageName: node
   linkType: hard
 
@@ -11313,7 +11313,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "noita-together@workspace:."
   dependencies:
-    "@noita-together/nt-message": ^0.0.1
+    "@noita-together/nt-message": 1.0.1
     axios: ^1.4.0
     prettier: latest
     ts-node: ^10.9.1


### PR DESCRIPTION
NOTE: when preparing the release, be sure to update the @noita-together/nt-message dependency; if you have the old version present from a previous build, it will not include the fix!

The frame encoder will no longer throw an error when receiving scale_x/scale_y values that aren't +-1, which was happening with the shrinking mage in the new enemies mod. Now, the encoder will encode a value such as -0.89 as -1. This means that other players won't see the scale change, but the NT app will not crash/fail on encoding the message.

I don't expect that adding this support is going to add a lot of value, so I don't have plans to build it, but if we learn of some demand we can go further.

