### PR TITLE
add "unbone ghost" option

### DIFF
--- a/noita_mod/core/files/append/unbone_ghosts.lua
+++ b/noita_mod/core/files/append/unbone_ghosts.lua
@@ -1,0 +1,12 @@
+local actual_old_SpawnApparition = SpawnApparition
+
+SpawnApparition = function(x, y, level, spawn_now)
+    spawn_now = spawn_now or false
+    local state, apparition = actual_old_SpawnApparition(x, y, level, spawn_now)
+    if (GameHasFlagRun("NT_unbone_ghosts") and apparition ~= nil) then
+        EntityKill(apparition)
+        return state, EntityLoad("data/entities/animals/playerghost.xml", x, y)
+    else
+        return state, apparition
+    end
+end

--- a/noita_mod/core/init.lua
+++ b/noita_mod/core/init.lua
@@ -25,6 +25,7 @@ for _,entry in pairs( pregen_wand_biomes ) do
     ModLuaFileAppend( entry, "mods/noita-together/files/append/preset_wands_random.lua" );
 end
 ModLuaFileAppend("data/scripts/biome_scripts.lua", "mods/noita-together/files/append/biome_scripts.lua")
+ModLuaFileAppend("data/scripts/biome_scripts.lua", "mods/noita-together/files/append/unbone_ghosts.lua")
 ModLuaFileAppend("data/scripts/items/generate_shop_item.lua", "mods/noita-together/files/append/generate_shop_item.lua")
 ModLuaFileAppend("data/scripts/gun/procedural/gun_procedural.lua", "mods/noita-together/files/append/gun_procedural.lua")
 ModLuaFileAppend("data/scripts/items/chest_random.lua", "mods/noita-together/files/append/chest_random.lua")
@@ -45,6 +46,11 @@ ModLuaFileAppend("data/scripts/perks/perk_pickup.lua", "mods/noita-together/file
 ModLuaFileAppend("data/scripts/perks/perk_reroll.lua", "mods/noita-together/files/append/perk_reroll.lua")
 ModLuaFileAppend("data/scripts/perks/perk.lua", "mods/noita-together/files/append/perk.lua")
 ModLuaFileAppend("data/scripts/magic/fungal_shift.lua", "mods/noita-together/files/append/fungal_shift.lua")
+
+-- due to the relevant code being in the global scope, we have to prepend this instead of appending
+local unbone_ghosts_text = ModTextFileGetContent("mods/noita-together/files/append/unbone_ghosts.lua")
+local boss_sky_text = ModTextFileGetContent("data/entities/animals/boss_sky/boss_sky.lua")
+ModTextFileSetContent("data/entities/animals/boss_sky/boss_sky.lua", unbone_ghosts_text .. boss_sky_text)
 
 --emote system mnee support
 if ModIsEnabled("mnee") then

--- a/nt-app/src/store/index.js
+++ b/nt-app/src/store/index.js
@@ -44,6 +44,7 @@ export const flagInfo = {
         "NT_send_flasks":                 { name: "Send Flasks", tooltip: "Allow players to deposit/take flasks." },
         "NT_send_gold":                   { name: "Send Gold", tooltip: "Allow players to deposit/take gold." },
         "NT_send_items":                  { name: "Send Items", tooltip: "Allow players to deposit/take items." },
+        "NT_unbone_ghosts":               { name: "Unbone Ghosts", tooltip: "Ghosts use random T3 wands instead of bone wands."},
         "NT_world_randomize_loot":        { name: "Randomize loot", tooltip: "Only applies when playing on the same seed, makes it so everyone gets different loot." },
         "NT_sync_world_seed":             { name: "Sync Seed", tooltip: "All players play in the same world seed (requires everyone to start a new game) 0 means random seed." },
         "NT_death_penalty": {
@@ -82,6 +83,7 @@ export const defaultFlags = {
         { id: "NT_send_flasks",                type: "boolean", value: true,  },
         { id: "NT_send_gold",                  type: "boolean", value: true,  },
         { id: "NT_send_items",                 type: "boolean", value: true,  },
+        { id: "NT_unbone_ghosts",              type: "boolean", value: false,  },
         { id: "NT_world_randomize_loot",       type: "boolean", value: true,  },
         { id: "NT_sync_world_seed",            type: "number" , value: 0,     },
         { id: "NT_death_penalty",              type: "enum",    value: 'end', choices: ['end', 'weak_respawn', 'full_respawn'], },


### PR DESCRIPTION
Related to Dunk's request to remove ghosts from NT, however instead of removing them entirely, it instead replaces them with the polymorph version of the player ghost which uses a random wand (Tier 3 wand, if I understood the code correctly). Also affects the Kivi player ghosts.

The way it's coded is a little jank, since I check if an entity was actually generated and then replace it rather than doing the check myself, but since the source code for spawning apparitions isn't in Lua I didn't want to make my life harder than it needed to be (assuming this approach doesn't have other issues I'm not aware of)

I can change it to remove them entirely if that's preferred, since that change would be even simpler, I just figured it would be a shame to remove them entirely.