### PR TITLE
Add the location of the orb to the '$0 found an orb' message ingame

### DIFF
--- a/noita_mod/core/files/scripts/utils.lua
+++ b/noita_mod/core/files/scripts/utils.lua
@@ -9,6 +9,8 @@ end
 dofile("mods/noita-together/files/scripts/util/player_ghosts.lua") --TODO make this a dofile_once ???
 dofile_once("mods/noita-together/files/scripts/util/coop_boss_fight.lua")
 
+local bit = require("bit")
+
 function GetPlayer()
     local player = EntityGetWithTag("player_unit") or nil
     if player ~= nil then
@@ -198,6 +200,28 @@ function PlayerHeartPickup(perk, userId)
         GamePrint(description)
     end
 end
+local orbIdToName = {
+    [0] = "$noitatogether_mountain",
+    [1] = "$biome_pyramid",
+    [2] = "$biome_vault_frozen",
+    [3] = "$noitatogether_location_lavalake",
+    [4] = "$biome_sandcave",
+    [5] = "$biome_wandcave",
+    [6] = "$biome_rainforest_dark",
+    [7] = "$noitatogether_location_abbc",
+    [8] = "$noitatogether_location_hell",
+    [9] = "$biome_winter_caves",
+    [10] = "$biome_wizardcave",
+    [11] = "$item_chest_treasure_super"
+}
+
+local function getOrbName(id)
+    if bit.band(id,384) ~= 0 then
+        local dir_key = ( bit.band(id,128) ~= 0 and "$biome_west" ) or "$biome_east"
+        return GameTextGet(dir_key, getOrbName(bit.band(id,127)))
+    end
+    return GameTextGet(orbIdToName[bit.band(id,127)] or "$noitatogether_orb_unknownid", id)
+end
 
 function PlayerOrbPickup(id, userId)
     async(
@@ -205,10 +229,10 @@ function PlayerOrbPickup(id, userId)
             local player = PlayerList[userId].name
             local already_picked = GameGetOrbCollectedThisRun(id)
             if (already_picked) then
-                GamePrint(GameTextGet("$noitatogether_player_got_orb_had", player))
+                GamePrint(GameTextGet("$noitatogether_player_got_orb_had", player, getOrbName(id)))
                 return nil
             end
-            GamePrint(GameTextGet("$noitatogether_player_got_orb", player))
+            GamePrint(GameTextGet("$noitatogether_player_got_orb", player, getOrbName(id)))
             local orb = EntityLoad("mods/noita-together/files/entities/forced_orb.xml", GetPlayerPos())
             local orbcomp = EntityGetFirstComponent(orb, "OrbComponent")
             ComponentSetValue2(orbcomp, "orb_id", id)

--- a/noita_mod/core/files/translations/translations.csv
+++ b/noita_mod/core/files/translations/translations.csv
@@ -51,8 +51,12 @@ noitatogether_teamperk_received_subtitle,Enjoy!,,,,,,,,,,,,subtitle of message w
 noitatogether_angered_gods_title,$0 angered the Gods,,,,,,,,,,,,title of message when a player angers the gods with sync steve,
 noitatogether_angered_gods_subtitle,Good luck,,,,,,,,,,,,subtitle of message when a player angers the gods with sync steve,
 noitatogether_player_got_heart,$0 picked up a heart,,,,,,,,,,,,message when player picks up a heart,
-noitatogether_player_got_orb_had,$0 found an orb of knowledge you had already found,,,,,,,,,,,,message when player picks up an orb you already found,
-noitatogether_player_got_orb,$0 found an orb of knowledge,,,,,,,,,,,,message when player picks up an orb,
+noitatogether_player_got_orb_had,$0 found an orb of knowledge you had already found ($1),,,,,,,,,,,,message when player picks up an orb you already found,
+noitatogether_player_got_orb,$0 found an orb of knowledge ($1),,,,,,,,,,,,message when player picks up an orb,
+noitatogether_location_lavalake,Lava Lake,,,,,,,,,,,,name of the lava lake (orb2 location)
+noitatogether_location_abbc,Bridge Boss,,,,,,,,,,,,name of the abbc (orb7 location)
+noitatogether_location_hell,Hell,,,,,,,,,,,,name of the work (hell) (orb8 location)
+noitatogether_orb_unknownid,BUG: UNKNOWN ORB ID $0?,,,,,,,,,,,,message when unknown orb id is picked
 noitatogether_heart_blocked_playercount,Unable to calculate proper health increase. Gave the min hp increase (bug),,,,,,,,,,,,message when player can't benefit from hearts,
 noitatogether_player_died,$0 died,,,,,,,,,,,,message when player died generically,
 noitatogether_run_end_lowhp_title,Not enough life force,,,,,,,,,,,,title of message when run ends due to respawn penalty dropping hp too low,


### PR DESCRIPTION
Update the ingame "$0 found an orb of knowledge" messages to also show which orb (by location). Additionally shows "east" or "west" for parallel world orbs.

Some locations don't have ingame translations, so adds (english only) translation keys for those