### PR TITLE
Disable drinking the starting flask during pre-run stage

### DIFF
--- a/noita_mod/core/files/scripts/utils.lua
+++ b/noita_mod/core/files/scripts/utils.lua
@@ -100,6 +100,26 @@ function ConvertStrToTable(data)
     return ret
 end
 
+function EntityGetNamedChild(entity,name)
+    local childs = EntityGetAllChildren(entity)
+    if childs ~= nil then
+        for _,child in ipairs(childs) do
+            if EntityGetName(child) == name then
+                return child
+            end
+        end
+    end
+    return nil
+end
+
+function GetPlayerInventoryQuick()
+    local player = GetPlayer()
+    if player then
+        return EntityGetNamedChild(player,"inventory_quick")
+    end
+    return nil
+end
+
 function GetPlayerWands()
     local player = GetPlayer()
     if (player == nil) then return {} end
@@ -125,18 +145,15 @@ function GetPlayerWands()
     return wands or nil
 end
 
-function GetPlayerInventory()
-    local childs = EntityGetAllChildren(GetPlayer())
-    local inven = nil
-    if childs ~= nil then
-        for _, child in ipairs(childs) do
-            if EntityGetName(child) == "inventory_full" then
-                inven = child
-            end
-        end
+function GetPlayerInventory() --full
+    local player = GetPlayer()
+    if player then
+        return EntityGetNamedChild(player,"inventory_full")
     end
-    return inven or nil
+    return nil
+
 end
+
 
 function AngerSteve(userId)
     if (NT.sent_steve or GlobalsGetValue("TEMPLE_SPAWN_GUARDIAN") == "1") then return nil end
@@ -719,6 +736,9 @@ function StartRun()
                 EntityRemoveTag(player, "polymorphable_NOT")
             end
             GameRemoveFlagRun("NT_added_poly_immune_prerun")
+
+            --Re-enable the starter potion now, too
+            SetStarterPotionDrinkable(true)
         end
 
         local cosmetics = CosmeticFlags()
@@ -726,6 +746,19 @@ function StartRun()
         GameAddFlagRun("NT_unlocked_controls")
         _start_run = false
         _started = true
+    end
+end
+
+function SetStarterPotionDrinkable(state)
+    local inven_quick = GetPlayerInventoryQuick()
+    if inven_quick then
+        local children = EntityGetAllChildren(inven_quick,"potion")
+        if children and #children > 0 then
+            local item_comp = EntityGetFirstComponentIncludingDisabled(children[1],"ItemComponent")
+            if item_comp then
+                ComponentSetValue2(item_comp,"drinkable",state and true or false)
+            end
+        end
     end
 end
 

--- a/noita_mod/core/init.lua
+++ b/noita_mod/core/init.lua
@@ -245,6 +245,10 @@ function OnPlayerSpawned(player_entity)
     if (not EntityHasTag(player_entity, "polymorphable_NOT")) then
         EntityAddTag(player_entity, "polymorphable_NOT")
         GameAddFlagRun("NT_added_poly_immune_prerun")
+
+        --also disable drinking the starting potion
+        --we will reenable this later ( utils.lua:StartRun() )
+        SetStarterPotionDrinkable(false)
     end
 
     if (ModSettingGet("noita-together.NT_HINTS")) then


### PR DESCRIPTION
Uses ItemComponent to disable drinking the starting flask before the run begins

Then re-enables it after the run is started by the host

This prevents chugging bad potions safely during run setup 😄

Left in the polymorph immunity part for now too, it doesn't hurt I guess.