### PR TITLE
dont require bitop library, that doesnt work in noita smh

### DIFF
--- a/noita_mod/core/files/scripts/utils.lua
+++ b/noita_mod/core/files/scripts/utils.lua
@@ -9,8 +9,6 @@ end
 dofile("mods/noita-together/files/scripts/util/player_ghosts.lua") --TODO make this a dofile_once ???
 dofile_once("mods/noita-together/files/scripts/util/coop_boss_fight.lua")
 
-local bit = require("bit")
-
 function GetPlayer()
     local player = EntityGetWithTag("player_unit") or nil
     if player ~= nil then


### PR DESCRIPTION
require(...) isn't in noita's api, and it seems we can use bitop just fine without doing that. Trying broke stuff during testing!