### PR TITLE
make stats header sticky

### DIFF
--- a/nt-web-app/websocket/stats/template.html
+++ b/nt-web-app/websocket/stats/template.html
@@ -28,6 +28,11 @@
         /**/
     }
 
+    thead {
+        position: sticky;
+        top: 0;
+    }
+
     th {
         background-color: rgb(55, 39, 36);
         color: rgba(255, 255, 255, 0.66);


### PR DESCRIPTION
Keeps stats header on screen while scrolling.

![image](https://github.com/user-attachments/assets/000b5556-a452-4396-a7ef-9841a448d073)
