### PR TITLE
make stats header sticky

### DIFF
--- a/nt-web-app/websocket/stats/templatebuilder.ts
+++ b/nt-web-app/websocket/stats/templatebuilder.ts
@@ -29,6 +29,11 @@ export const templateHtml = `
         /**/
     }
 
+    thead {
+        position: sticky;
+        top: 0;
+    }
+
     th {
         background-color: rgb(55, 39, 36);
         color: rgba(255, 255, 255, 0.66);


### PR DESCRIPTION
Another try to style stats table header. Seems like the changed template from #212 is actually not used to show stats to the users.

Currently it seems that after /endrun, stats are generated using the `StaticStatsPageGenerator`, `template.html` and `template-segment-user.html` from `websocket/stats/...`. Those stats get saved until owner leaves lobby, however whenever request is made to get stats, the [handler](https://github.com/Noita-Together/noita-together/blob/8091cff5ea1d31bdf9ff750948ec872471927f30/nt-web-app/pages/api/stats/%5Bid%5D/%5BsessionId%5D/html.ts#L8) creates new stats by using `templatebuilder.ts` without using the template file.

Is there a reason for keeping both ways of stats generation?